### PR TITLE
Add small threshold to BarUI.CheckDrag method

### DIFF
--- a/UI/BarUI.cs
+++ b/UI/BarUI.cs
@@ -397,7 +397,7 @@ namespace QoLBar
             {
                 // I greatly dislike this
                 var dragging = !IsDragging
-                    ? ImGui.IsWindowFocused() && IsHovered && !ImGui.IsMouseClicked(ImGuiMouseButton.Left) && ImGui.IsMouseDragging(ImGuiMouseButton.Left, 0)
+                    ? ImGui.IsWindowFocused() && IsHovered && !ImGui.IsMouseClicked(ImGuiMouseButton.Left) && ImGui.IsMouseDragging(ImGuiMouseButton.Left, 5)
                     : IsDragging && !ImGui.IsMouseReleased(ImGuiMouseButton.Left);
 
                 // Began dragging


### PR DESCRIPTION
Fixes the (very minor) issue we discussed, reducing incidences of accidental movement of unlocked bars and allowing unlocked category commands to be clicked.