### PR TITLE
Change Penumbra Version Check

### DIFF
--- a/IPC.cs
+++ b/IPC.cs
@@ -53,7 +53,7 @@ public static class IPC
 
     public static void EnablePenumbraApi()
     {
-        if (PenumbraApiVersion != 4) return;
+        if (PenumbraApiVersion < 4) return;
 
         PenumbraEnabled = true;
 


### PR DESCRIPTION
I will try my hardest to keep backwards compatibility for Penumbra IPC from ApiVersion 5 onwards (4 -> 5 did not change anything relevant for you either), so I think just doing a >= check should be fine.
Should I be forced to break API concerning you I will give you a heads up.