### PR TITLE
Update IPC.cs

### DIFF
--- a/IPC.cs
+++ b/IPC.cs
@@ -20,13 +20,13 @@ public static class IPC
     public static bool PenumbraEnabled { get; private set; } = false;
     private static ICallGateSubscriber<object> penumbraInitializedSubscriber;
     private static ICallGateSubscriber<object> penumbraDisposedSubscriber;
-    private static ICallGateSubscriber<int> penumbraApiVersionSubscriber;
+    private static ICallGateSubscriber<(int Breaking, int Features)> penumbraApiVersionsSubscriber;
     private static ICallGateSubscriber<string, string> penumbraResolveDefaultSubscriber;
     public static int PenumbraApiVersion
     {
         get
         {
-            try { return penumbraApiVersionSubscriber.InvokeFunc(); }
+            try { return penumbraApiVersionsSubscriber.InvokeFunc().Breaking; }
             catch { return 0; }
         }
     }
@@ -41,7 +41,7 @@ public static class IPC
 
         penumbraInitializedSubscriber = DalamudApi.PluginInterface.GetIpcSubscriber<object>("Penumbra.Initialized");
         penumbraDisposedSubscriber = DalamudApi.PluginInterface.GetIpcSubscriber<object>("Penumbra.Disposed");
-        penumbraApiVersionSubscriber = DalamudApi.PluginInterface.GetIpcSubscriber<int>("Penumbra.ApiVersion");
+        penumbraApiVersionsSubscriber = DalamudApi.PluginInterface.GetIpcSubscriber<(int, int)>("Penumbra.ApiVersions");
         penumbraResolveDefaultSubscriber = DalamudApi.PluginInterface.GetIpcSubscriber<string, string>("Penumbra.ResolveDefaultPath");
 
         penumbraInitializedSubscriber.Subscribe(EnablePenumbraApi);
@@ -53,7 +53,7 @@ public static class IPC
 
     public static void EnablePenumbraApi()
     {
-        if (PenumbraApiVersion < 4) return;
+        if (PenumbraApiVersion != 4) return;
 
         PenumbraEnabled = true;
 


### PR DESCRIPTION
I changed my mind on how to handle versions and provide two API Versions now, the major one will only change on breaking changes, while the minor changes on any addition, too.
So for your use case we check for equality on the major again. 
This change is not breaking since it's a new IPC function, so this should remain working even before you accept the PR, but give a log warning when the old Penumbra.ApiVersion is called.
So you don't need to hurry or anything. :)

(have not tested the changes, just done in github directly)