### PR TITLE
Add "level greater than or equal to" and "level less than" conditions

### DIFF
--- a/Conditions/Level.cs
+++ b/Conditions/Level.cs
@@ -1,0 +1,51 @@
+using System;
+using ImGuiNET;
+
+namespace QoLBar.Conditions;
+
+[AttributeUsage(AttributeTargets.Class)]
+public class LevelConditionAttribute : Attribute, IConditionCategory
+{
+    public string CategoryName => "Level";
+    public int DisplayPriority => 0;
+}
+
+[LevelCondition]
+public class LevelGreaterEqualCondition : ICondition, IDrawableCondition, IArgCondition
+{
+    public string ID => "lge";
+    public string ConditionName => "is greater than or equal to";
+    public int DisplayPriority => 0;
+    public bool Check(dynamic arg) => DalamudApi.ClientState.LocalPlayer is { } player && player.Level >= (uint)arg;
+    public string GetTooltip(CndCfg cndCfg) => "Ctrl + Left Click to enter a value as text";
+    public string GetSelectableTooltip(CndCfg cndCfg) => null;
+    public void Draw(CndCfg cndCfg) 
+    {
+        var _ = (int)cndCfg.Arg;
+        if (ImGui.SliderInt("##LevelSlider", ref _, 1, 100))
+        {
+            cndCfg.Arg = _;
+        }
+    }
+    public dynamic GetDefaultArg(CndCfg cndCfg) => DalamudApi.ClientState.LocalPlayer?.Level ?? 0;
+}
+
+[LevelCondition]
+public class LevelLessCondition : ICondition, IDrawableCondition, IArgCondition
+{
+    public string ID => "llt";
+    public string ConditionName => "is less than";
+    public int DisplayPriority => 0;
+    public bool Check(dynamic arg) => DalamudApi.ClientState.LocalPlayer is { } player && player.Level < (uint)arg;
+    public string GetTooltip(CndCfg cndCfg) => "Ctrl + Left Click to enter a value as text";
+    public string GetSelectableTooltip(CndCfg cndCfg) => null;
+    public void Draw(CndCfg cndCfg) 
+    {
+        var _ = (int)cndCfg.Arg;
+        if (ImGui.SliderInt("##LevelSlider", ref _, 1, 100))
+        {
+            cndCfg.Arg = _;
+        }
+    }
+    public dynamic GetDefaultArg(CndCfg cndCfg) => DalamudApi.ClientState.LocalPlayer?.Level ?? 0;
+}


### PR DESCRIPTION
I realised as I was setting up some quick-access bars for some jobs that I there wasn't a way to check the player's level. I have a few bars that I use for quickly using specific actions on specific party members, and I don't want them appearing if I don't have that ability.

So I made a quick pair of conditions. The names are a little non-standard, but I think they look quite nice in use.
![image](https://github.com/user-attachments/assets/cf6dd00e-2622-453c-b9a4-59589edb1b74)

The two were chosen to cover nearly every use case I could think of, as there wasn't really anything proper I could think of that would want an equal (and that can still be done by combining the two conditions if absolutely necessary).

I'm still quite new to Dalamud, ImGui, and C# overall, so I hope everything is right.